### PR TITLE
Updating the following package versions to address dependabot alerts:…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2018.11.29
 cffi==1.12.1
 chardet==3.0.4
 Click==7.0
-cryptography==2.5
+cryptography==3.2
 google-auth==1.6.3
 idna==2.8
 kubernetes==8.0.1
@@ -15,13 +15,13 @@ oauthlib==3.0.1
 pyasn1==0.4.5
 pyasn1-modules==0.2.4
 pycparser==2.19
-Pygments==2.3.1
+Pygments==2.7.4
 PyJWT==1.7.1
 python-dateutil==2.8.0
-PyYAML==3.13
+PyYAML==5.4
 requests==2.21.0
 requests-oauthlib==1.2.0
-rsa==4.1
+rsa==4.7
 six==1.12.0
-urllib3==1.24.2
+urllib3==1.26.5
 websocket-client==0.54.0


### PR DESCRIPTION
… urllib3 to 1.26.5, rsa to 4.7, Pygments to 2.7.4, PyYAML to 5.4, cryptograpphy to 3.2.